### PR TITLE
Refactor chart panels and utilities

### DIFF
--- a/src/components/chart/CandlestickChart.tsx
+++ b/src/components/chart/CandlestickChart.tsx
@@ -1,28 +1,13 @@
 'use client'
-
-import {
-  createChart,
-  CandlestickData,
-  HistogramData,
-  IChartApi,
-  ISeriesApi,
-  CrosshairMode,
-  LineData,
-  UTCTimestamp
-} from 'lightweight-charts'
-import { useEffect, useRef, useCallback } from 'react'
-import { useTheme } from 'next-themes'
+import { createChart, CandlestickData, HistogramData, IChartApi, ISeriesApi, CrosshairMode } from 'lightweight-charts'
+import { useEffect, useRef } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
-import IndicatorPanel from './IndicatorPanel'
-import {
-  computeSMA,
-  computeRSI,
-  computeMACD,
-  computeBollinger,
-} from '@/lib/indicators'
-import useBinanceSocket from '@/hooks/use-binance-socket'
+import useChartTheme from '@/hooks/use-chart-theme'
 import useCandlestickData from '@/hooks/use-candlestick-data'
-
+import { processTimeSeriesData } from '@/lib/chart-utils'
+import useLineSeries from '@/hooks/use-line-series'
+import RsiPanel from './RsiPanel'
+import MacdPanel from './MacdPanel'
 
 interface IndicatorOptions {
   ma: boolean
@@ -42,9 +27,7 @@ interface CandlestickChartProps {
 }
 
 /**
- * Binanceのローソク足データを表示するチャートコンポーネント
- * APIモードでは/api/candlesエンドポイントからデータを取得
- * 直接モードではBinance APIに直接アクセス
+ * Binanceのローソク足を表示するチャート
  */
 export default function CandlestickChart({
   className,
@@ -55,226 +38,50 @@ export default function CandlestickChart({
   indicators = { ma: false, rsi: false, macd: false, boll: false },
   onIndicatorsChange
 }: CandlestickChartProps) {
-  const { theme = 'light' } = useTheme()
-  
-  // テーマに応じた色を取得する関数
-  const getThemeColors = useCallback(() => {
-    const isDark = theme === 'dark'
-    return {
-      background: isDark ? '#1e1e1e' : '#ffffff',
-      text: isDark ? '#d1d5db' : '#111827',
-      grid: isDark ? '#2f3338' : '#e0e0e0',
-      crosshair: isDark ? '#d1d5db' : '#111827',
-      upColor: '#26a69a',
-      downColor: '#ef5350',
-      volume: '#4b5563'
-    }
-  }, [theme])
-  
-  // テーマカラーをメモ化
-  const themeColors = getThemeColors()
-  const containerRef = useRef<HTMLDivElement>(null)  // メインチャートとシリーズの参照
+  const colors = useChartTheme()
+  const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
-  const candleSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
-  const volumeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null)
-  const maSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
-  const bollUpperSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
-  const bollLowerSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
-  const closePricesRef = useRef<number[]>([]) // 終値データを追跡するための参照
+  const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
+  const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+  const maRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const bollUpperRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const bollLowerRef = useRef<ISeriesApi<'Line'> | null>(null)
 
-  // RSIパネル用のチャートと系列の参照
-  const rsiChartRef = useRef<IChartApi | null>(null)
-  const rsiSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const { candles = [], volumes = [], ma = [], rsi = [], macd = [], signal = [], bollUpper = [], bollLower = [], loading, error } = useCandlestickData(initialSymbol, initialInterval)
 
-  // MACDパネル用のチャートと系列の参照
-  const macdChartRef = useRef<IChartApi | null>(null)
-  const macdSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
-  const signalSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
-  const histogramSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+  useLineSeries({ chart: chartRef.current, ref: maRef, enabled: indicators.ma, options: { color: '#f59e0b', lineWidth: 2, priceLineVisible: false }, data: ma })
+  useLineSeries({ chart: chartRef.current, ref: bollUpperRef, enabled: indicators.boll, options: { color: '#a855f7', lineWidth: 1, priceLineVisible: false }, data: bollUpper })
+  useLineSeries({ chart: chartRef.current, ref: bollLowerRef, enabled: indicators.boll, options: { color: '#a855f7', lineWidth: 1, priceLineVisible: false }, data: bollLower })
 
-  const {
-    candles = [],
-    volumes = [],
-    ma = [],
-    rsi = [],
-    macd = [],
-    signal: signalData = [],
-    bollUpper = [],
-    bollLower = [],
-    loading,
-    error
-  } = useCandlestickData(initialSymbol, initialInterval)
-
-  const handleSocketMessage = useCallback(
-    (msg: any) => {
-      const k = msg.k
-      const candle: CandlestickData = {
-        time: (k.t / 1000) as UTCTimestamp,
-        open: parseFloat(k.o),
-        high: parseFloat(k.h),
-        low: parseFloat(k.l),
-        close: parseFloat(k.c),
-      }
-      candleSeriesRef.current?.update(candle)
-      const volume: HistogramData = {
-        time: (k.t / 1000) as UTCTimestamp,
-        value: parseFloat(k.v),
-        color: parseFloat(k.c) >= parseFloat(k.o) ? '#26a69a' : '#ef5350',
-      }
-      volumeSeriesRef.current?.update(volume)
-
-      closePricesRef.current.push(candle.close)
-      if (closePricesRef.current.length > 1000) closePricesRef.current.shift()
-
-      const ma = computeSMA(closePricesRef.current, 14)
-      if (ma !== null && maSeriesRef.current) {
-        maSeriesRef.current.update({ time: candle.time, value: ma })
-      }
-
-      const rsi = computeRSI(closePricesRef.current, 14)
-      if (rsi !== null && rsiSeriesRef.current) {
-        rsiSeriesRef.current.update({ time: candle.time, value: rsi })
-      }
-
-      const macd = computeMACD(closePricesRef.current)
-      if (macd && macdSeriesRef.current && signalSeriesRef.current) {
-        macdSeriesRef.current.update({ time: candle.time, value: macd.macd })
-        signalSeriesRef.current.update({ time: candle.time, value: macd.signal })
-      }
-
-      const boll = computeBollinger(closePricesRef.current)
-      if (boll && bollUpperSeriesRef.current && bollLowerSeriesRef.current) {
-        bollUpperSeriesRef.current.update({ time: candle.time, value: boll.upper })
-        bollLowerSeriesRef.current.update({ time: candle.time, value: boll.lower })
-      }
-    },
-    []
-  )
-
-  useBinanceSocket({
-    url: `wss://stream.binance.com:9443/ws/${initialSymbol.toLowerCase()}@kline_${initialInterval}`,
-    onMessage: handleSocketMessage,
-  })
-
-  // チャートの初期化
   useEffect(() => {
     if (!containerRef.current) return
-
-    const colors = getThemeColors()
-
     const chart = createChart(containerRef.current, {
       width: containerRef.current.clientWidth,
       height,
-      layout: {
-        background: { color: colors.background },
-        textColor: colors.text,
-      },
-      // グリッド線の色をテーマに合わせる
-      grid: {
-        vertLines: { color: colors.grid },
-        horzLines: { color: colors.grid },
-      },
-      // クロスヘア設定: 常に表示しラインの色を調整
+      layout: { background: { color: colors.background }, textColor: colors.text },
+      grid: { vertLines: { color: colors.grid }, horzLines: { color: colors.grid } },
       crosshair: {
         mode: CrosshairMode.Normal,
-        vertLine: { 
-          color: colors.crosshair,
-          labelVisible: true,
-          labelBackgroundColor: colors.background
-        },
-        horzLine: { 
-          color: colors.crosshair,
-          labelVisible: true,
-          labelBackgroundColor: colors.background
-        }
+        vertLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background },
+        horzLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background }
       },
-      // 価格スケール: 枠線を表示して価格ラインのスペースを確保
       rightPriceScale: {
         borderColor: colors.grid,
         borderVisible: true,
-        scaleMargins: {
-          top: 0.1, // 上部に少し余白を持たせる
-          bottom: 0.2, // 下部に20%の余薄を確保し、インジケーターのスペースを作る
-        },
+        scaleMargins: { top: 0.1, bottom: 0.2 }
       },
-      timeScale: { 
-        borderColor: colors.grid, 
-        timeVisible: true 
-      },
+      timeScale: { borderColor: colors.grid, timeVisible: true }
     })
-
     chartRef.current = chart
-    candleSeriesRef.current = chart.addCandlestickSeries({
+    candleRef.current = chart.addCandlestickSeries({
       upColor: colors.upColor,
       downColor: colors.downColor,
       wickUpColor: colors.upColor,
       wickDownColor: colors.downColor,
-      borderVisible: false,
+      borderVisible: false
     })
-    
-    volumeSeriesRef.current = chart.addHistogramSeries({
-      priceFormat: { type: 'volume' },
-      priceScaleId: 'vol',
-      color: colors.volume,
-    })
-
-    // データがあれば複数のローソク足データを再設定する
-    const storedCandles = localStorage.getItem(`candles_${initialSymbol}_${initialInterval}`)
-    const storedVolumes = localStorage.getItem(`volumes_${initialSymbol}_${initialInterval}`)
-    if (storedCandles && candleSeriesRef.current) {
-      try {
-        const candles = JSON.parse(storedCandles) as CandlestickData[]
-        candleSeriesRef.current.setData(candles)
-      } catch (e) {
-        console.error('Failed to parse stored candles', e)
-      }
-    }
-    if (storedVolumes && volumeSeriesRef.current) {
-      try {
-        const volumes = JSON.parse(storedVolumes) as HistogramData[]
-        volumeSeriesRef.current.setData(volumes)
-      } catch (e) {
-        console.error('Failed to parse stored volumes', e)
-      }
-    }
-
-    // メイン価格チャートに追加するインジケーター
-    if (indicators.ma) {
-      maSeriesRef.current = chart.addLineSeries({ 
-        color: '#f59e0b', 
-        lineWidth: 2, 
-        priceLineVisible: false,
-        // メイン価格チャートに表示
-        priceScaleId: 'right' 
-      })
-    }
-    if (indicators.boll) {
-      bollUpperSeriesRef.current = chart.addLineSeries({ 
-        color: '#a855f7', 
-        lineWidth: 1, 
-        priceLineVisible: false,
-        // メイン価格チャートに表示
-        priceScaleId: 'right' 
-      })
-      bollLowerSeriesRef.current = chart.addLineSeries({ 
-        color: '#a855f7', 
-        lineWidth: 1, 
-        priceLineVisible: false,
-        // メイン価格チャートに表示
-        priceScaleId: 'right' 
-      })
-    }
-    
-    // RSIとMACDは専用パネルで表示するためメインチャートには追加しない
-
-    // ボリュームのスケール設定 - より小さく表示
-    chart.priceScale('vol').applyOptions({
-      scaleMargins: {
-        top: 0.9, // 上部に90%のスペースを確保し、ボリュームはより小さく
-        bottom: 0,
-      },
-    });
-
+    volumeRef.current = chart.addHistogramSeries({ priceFormat: { type: 'volume' }, priceScaleId: 'vol', color: colors.volume })
+    chart.priceScale('vol').applyOptions({ scaleMargins: { top: 0.9, bottom: 0 } })
     const handleResize = () => {
       if (containerRef.current && chartRef.current) {
         chartRef.current.resize(containerRef.current.clientWidth, height)
@@ -284,624 +91,63 @@ export default function CandlestickChart({
     return () => {
       window.removeEventListener('resize', handleResize)
       chart.remove()
+      chartRef.current = null
     }
-  // チャートの初期化依存配列からindicatorsを除外
-  // indicatorsの変更時にチャートを再作成するとローソク足がリセットされる
-  }, [theme, height])
+  }, [colors, height])
 
-  // テーマ変更時のスタイル更新
   useEffect(() => {
     if (!chartRef.current) return
-    
-    const colors = getThemeColors()
-    
-    // チャートのスタイルを更新
     chartRef.current.applyOptions({
-      layout: {
-        background: { color: colors.background },
-        textColor: colors.text,
-      },
-      grid: {
-        vertLines: { color: colors.grid },
-        horzLines: { color: colors.grid },
-      },
+      layout: { background: { color: colors.background }, textColor: colors.text },
+      grid: { vertLines: { color: colors.grid }, horzLines: { color: colors.grid } },
       crosshair: {
         mode: CrosshairMode.Normal,
-        vertLine: { 
-          color: colors.crosshair,
-          labelVisible: true,
-          labelBackgroundColor: colors.background
-        },
-        horzLine: { 
-          color: colors.crosshair,
-          labelVisible: true,
-          labelBackgroundColor: colors.background
-        }
+        vertLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background },
+        horzLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background }
       },
-      rightPriceScale: { 
-        borderColor: colors.grid,
-        borderVisible: true
-      },
-      timeScale: { 
-        borderColor: colors.grid,
-        timeVisible: true
-      },
+      rightPriceScale: { borderColor: colors.grid },
+      timeScale: { borderColor: colors.grid }
     })
-    
-    // ローソク足の色も更新
-    if (candleSeriesRef.current) {
-      candleSeriesRef.current.applyOptions({
-        upColor: colors.upColor,
-        downColor: colors.downColor,
-        wickUpColor: colors.upColor,
-        wickDownColor: colors.downColor,
-        borderVisible: false,
-      })
-    }
-    
-    // ボリュームの色も更新
-    if (volumeSeriesRef.current) {
-      volumeSeriesRef.current.applyOptions({
-        color: colors.volume
-      })
-    }
-  }, [theme, getThemeColors])
+    candleRef.current?.applyOptions({
+      upColor: colors.upColor,
+      downColor: colors.downColor,
+      wickUpColor: colors.upColor,
+      wickDownColor: colors.downColor,
+      borderVisible: false
+    })
+    volumeRef.current?.applyOptions({ color: colors.volume })
+  }, [colors])
 
-  // データの前処理：タイムスタンプでソートし、重複を除去する関数
-  const preprocessLineData = (arr: LineData[]): LineData[] => {
-    if (!arr || arr.length === 0) return []
-
-    const getNumTime = (t: LineData['time']): number => {
+  useEffect(() => {
+    const toNum = (t: unknown): number => {
       if (typeof t === 'number') return t
-      // BusinessDay object -> Date
-      if (typeof t === 'object' && t !== null && 'year' in t && 'month' in t && 'day' in t) {
-        const bd = t as { year: number; month: number; day: number }
-        return Math.floor(new Date(bd.year, bd.month - 1, bd.day).getTime() / 1000)
-      }
-      // オブジェクトでvalueOfがあれば使用
-      if (typeof t === 'object' && t !== null && 'valueOf' in t) {
-        return (t as any).valueOf();
-      }
-      // string fallback
-      return Math.floor(new Date(t as unknown as string).getTime() / 1000)
+      if (typeof t === 'string') return Math.floor(new Date(t).getTime() / 1000)
+      if (typeof t === 'object' && t !== null && 'valueOf' in t) return (t as any).valueOf()
+      return 0
     }
-
-    // Step 1: タイムスタンプをキーとして使用して重複を除去するMap
-    const timeMap = new Map<number, LineData>();
-    arr.forEach(item => {
-      const timeKey = getNumTime(item.time);
-      if (!timeMap.has(timeKey)) {
-        timeMap.set(timeKey, item);
-      }
-    });
-
-    // Step 2: 一意のデータを配列に変換
-    const uniqueData = Array.from(timeMap.values());
-
-    // Step 3: 厳密に昇順でソート
-    const sortedData = uniqueData.sort((a, b) => {
-      const timeA = getNumTime(a.time);
-      const timeB = getNumTime(b.time);
-      return timeA - timeB;
-    });
-
-    // Step 4: 最終確認 - 隣接する項目が同じタイムスタンプを持っていないことを確認
-    const finalData: LineData[] = [];
-    let prevTime: number | null = null;
-    
-    for (const item of sortedData) {
-      const currentTime = getNumTime(item.time);
-      if (prevTime !== currentTime) {
-        finalData.push(item);
-        prevTime = currentTime;
-      }
+    if (candleRef.current && candles.length > 0) {
+      candleRef.current.setData(processTimeSeriesData<CandlestickData>(candles, toNum))
     }
-
-    return finalData;
-  }
-
-  const ensureSeries = (
-    cond: boolean,
-    ref: React.MutableRefObject<ReturnType<IChartApi['addLineSeries']> | null>,
-    opts: any,
-    data: LineData[]
-  ) => {
-    const chartInstance = chartRef.current
-    if (cond) {
-      if (chartInstance && !ref.current) {
-        ref.current = chartInstance.addLineSeries(opts)
-      }
-      const preprocessed = preprocessLineData(data)
-      if (ref.current && preprocessed.length > 0) {
-        ref.current.setData(preprocessed)
-      }
-    } else if (ref.current && chartInstance) {
-      try {
-        chartInstance.removeSeries(ref.current)
-      } catch (e) {
-        console.error('Error removing series:', e)
-      }
-      ref.current = null
+    if (volumeRef.current && volumes.length > 0) {
+      volumeRef.current.setData(processTimeSeriesData<HistogramData>(volumes, toNum))
     }
-  }
+  }, [candles, volumes])
 
-  // インジケーター表示切り替え
-  useEffect(() => {
-    if (!chartRef.current) return
-    const chart = chartRef.current
+  if (loading && useApi) return <Skeleton data-testid="loading" className="w-full h-[300px]" />
+  if (error && useApi) return <div data-testid="error" className="text-center text-sm text-red-500">{error}</div>
 
-    // MAシリーズの表示・非表示
-    ensureSeries(indicators.ma, maSeriesRef, { color: '#f59e0b', lineWidth: 2, priceLineVisible: false }, ma)
-
-    // MACDはメインチャートには表示せず、専用パネルで表示するため、
-    // メインチャートからMACDシリーズを常に削除
-    if (macdSeriesRef.current) {
-      try {
-        chart.removeSeries(macdSeriesRef.current)
-        macdSeriesRef.current = null
-      } catch (e) {
-        console.error('Error removing MACD series:', e)
-      }
-    }
-    if (signalSeriesRef.current) {
-      try {
-        chart.removeSeries(signalSeriesRef.current)
-        signalSeriesRef.current = null
-      } catch (e) {
-        console.error('Error removing signal series:', e)
-      }
-    }
-
-    // ボリンジャーバンドの表示・非表示
-    if (indicators.boll) {
-      ensureSeries(true, bollUpperSeriesRef, { color: '#a855f7', lineWidth: 1, priceLineVisible: false }, bollUpper)
-      ensureSeries(true, bollLowerSeriesRef, { color: '#a855f7', lineWidth: 1, priceLineVisible: false }, bollLower)
-    } else {
-      if (bollUpperSeriesRef.current && chart) {
-        try {
-          chart.removeSeries(bollUpperSeriesRef.current)
-          bollUpperSeriesRef.current = null
-        } catch (e) {
-          console.error('Error removing bollinger upper series:', e)
-        }
-      }
-      if (bollLowerSeriesRef.current && chart) {
-        try {
-          chart.removeSeries(bollLowerSeriesRef.current)
-          bollLowerSeriesRef.current = null
-        } catch (e) {
-          console.error('Error removing bollinger lower series:', e)
-        }
-      }
-    }
-  }, [indicators, ma, bollUpper, bollLower])
-
-  // タイムスタンプでソートし、重複を削除する関数
-  const processTimeSeriesData = <T extends { time: unknown }>(
-    data: T[],
-    timeToNumber: (time: unknown) => number
-  ): T[] => {
-    if (!data || data.length === 0) return [];
-
-    try {
-      // Step 1: タイムスタンプをキーとして使用して重複を除去するMap
-      const timeMap = new Map<number, T>();
-      
-      // 各データ項目を処理
-      data.forEach(item => {
-        const timeKey = timeToNumber(item.time);
-        if (!timeMap.has(timeKey)) {
-          timeMap.set(timeKey, item);
-        }
-      });
-      
-      // Step 2: 一意のデータを配列に変換
-      const uniqueData = Array.from(timeMap.values());
-      
-      // Step 3: 厳密に昇順でソート
-      const sortedData = uniqueData.sort((a, b) => {
-        const timeA = timeToNumber(a.time);
-        const timeB = timeToNumber(b.time);
-        return timeA - timeB;
-      });
-      
-      // Step 4: 最終確認 - 隣接する項目が同じタイムスタンプを持っていないことを確認
-      const finalData: T[] = [];
-      let prevTime: number | null = null;
-      
-      for (const item of sortedData) {
-        const currentTime = timeToNumber(item.time);
-        if (prevTime !== currentTime) {
-          finalData.push(item);
-          prevTime = currentTime;
-        }
-      }
-      
-      return finalData;
-    } catch (error) {
-      console.error('Error processing time series data:', error);
-      return [];
-    }
-  };
-
-  useEffect(() => {
-    const timeToNumber = (time: unknown): number => {
-      if (time === null || time === undefined) return 0;
-      if (typeof time === 'number') return time;
-      if (typeof time === 'string') {
-        const timestamp = new Date(time).getTime() / 1000;
-        return isNaN(timestamp) ? 0 : Math.floor(timestamp);
-      }
-      if (typeof time === 'object' && time !== null) {
-        if ('timestamp' in time && time.timestamp !== undefined) {
-          return timeToNumber(time.timestamp);
-        }
-      }
-      return 0;
-    };
-
-    try {
-      // ローソク足データを処理
-      if (candleSeriesRef.current && Array.isArray(candles) && candles.length > 0) {
-        const processedCandles = processTimeSeriesData<CandlestickData>(candles, timeToNumber);
-        if (processedCandles.length > 0) {
-          candleSeriesRef.current.setData(processedCandles);
-        }
-      }
-      
-      // ボリュームデータを処理
-      if (volumeSeriesRef.current && Array.isArray(volumes) && volumes.length > 0) {
-        const processedVolumes = processTimeSeriesData<HistogramData>(volumes, timeToNumber);
-        if (processedVolumes.length > 0) {
-          volumeSeriesRef.current.setData(processedVolumes);
-        }
-      }
-    } catch (error) {
-      console.error('Error updating chart data:', error);
-    }
-    if (maSeriesRef.current && ma && ma.length > 0) {
-      maSeriesRef.current.setData(preprocessLineData(ma as LineData[]))
-    }
-    if (rsiSeriesRef.current && rsi && rsi.length > 0) {
-      rsiSeriesRef.current.setData(preprocessLineData(rsi as LineData[]))
-    }
-    if (macdSeriesRef.current && macd && macd.length > 0) {
-      macdSeriesRef.current.setData(preprocessLineData(macd as LineData[]))
-    }
-    if (signalSeriesRef.current && signalData && signalData.length > 0) {
-      signalSeriesRef.current.setData(preprocessLineData(signalData as LineData[]))
-    }
-    if (bollUpperSeriesRef.current && bollUpper && bollUpper.length > 0) {
-      bollUpperSeriesRef.current.setData(preprocessLineData(bollUpper as LineData[]))
-    }
-    if (bollLowerSeriesRef.current && bollLower && bollLower.length > 0) {
-      bollLowerSeriesRef.current.setData(preprocessLineData(bollLower as LineData[]))
-    }
-  }, [candles, volumes, ma, rsi, macd, signalData, bollUpper, bollLower])
-
-
-
-  // ローディング中の表示
-  if (loading && useApi) {
-    return <Skeleton data-testid="loading" className="w-full h-[300px]" />;
-  }
-
-  // エラー表示
-  if (error && useApi) {
-    return (
-      <div data-testid="error" className="text-center text-sm text-red-500">
-        {error}
-      </div>
-    );
-  }
-
-  const initRsiChart = useCallback(
-    (el: HTMLDivElement) => {
-      const rsiChart = createChart(el, {
-        width: el.clientWidth,
-        height: height * 0.25,
-        layout: {
-          background: { color: theme === 'dark' ? '#1e1e1e' : '#ffffff' },
-          textColor: theme === 'dark' ? '#d1d5db' : '#111827',
-          fontFamily: 'Inter, sans-serif',
-        },
-        grid: {
-          vertLines: { color: theme === 'dark' ? '#2f3338' : '#e0e0e0' },
-          horzLines: { color: theme === 'dark' ? '#2f3338' : '#e0e0e0' },
-        },
-        rightPriceScale: { 
-          borderColor: theme === 'dark' ? '#2f3338' : '#e0e0e0',
-          scaleMargins: {
-            top: 0.1,
-            bottom: 0.1,
-          }
-        },
-        timeScale: {
-          borderColor: theme === 'dark' ? '#2f3338' : '#e0e0e0',
-          timeVisible: true,
-          secondsVisible: false,
-        },
-        crosshair: {
-          mode: CrosshairMode.Normal,
-          vertLine: { 
-            labelVisible: true,
-          },
-          horzLine: { 
-            labelVisible: true,
-          }
-        },
-      })
-
-      rsiChartRef.current = rsiChart
-      
-      // RSIラインの追加
-      rsiSeriesRef.current = rsiChart.addLineSeries({
-        color: '#2962FF',
-        lineWidth: 2,
-        title: 'RSI',
-        priceLineVisible: false,
-        lastValueVisible: true,
-      })
-      
-      // オーバーボート/オーバーソールドラインの追加
-      const overSoldLine = rsiChart.addLineSeries({
-        color: 'rgba(239, 83, 80, 0.5)',
-        lineWidth: 1,
-        lineStyle: 1, // 点線
-        priceLineVisible: false,
-        lastValueVisible: false,
-      });
-      
-      const overBoughtLine = rsiChart.addLineSeries({
-        color: 'rgba(38, 166, 154, 0.5)',
-        lineWidth: 1,
-        lineStyle: 1, // 点線
-        priceLineVisible: false,
-        lastValueVisible: false,
-      });
-      
-      // RSIの一般的な閾値
-      const timeFrom = Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30; // 30日前
-      const timeTo = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 1日後
-      
-      // オーバーソールド(30)ライン
-      overSoldLine.setData([
-        { time: timeFrom as UTCTimestamp, value: 30 },
-        { time: timeTo as UTCTimestamp, value: 30 }
-      ]);
-      
-      // オーバーボート(70)ライン
-      overBoughtLine.setData([
-        { time: timeFrom as UTCTimestamp, value: 70 },
-        { time: timeTo as UTCTimestamp, value: 70 }
-      ]);
-      
-      // RSIデータの設定
-      if (rsiSeriesRef.current && rsi && rsi.length > 0) {
-        rsiSeriesRef.current.setData(preprocessLineData(rsi as LineData[]))
-      } else if (rsiSeriesRef.current) {
-        // データがない場合でもグラフを表示するためのダミーデータ
-        rsiSeriesRef.current.setData([{ time: Math.floor(Date.now() / 1000) as UTCTimestamp, value: 50 }])
-      }
-      
-      // メインチャートとの同期
-      if (chartRef.current) {
-        const syncTimeScale = (range: any) => {
-          if (rsiChartRef.current && range !== null) {
-            rsiChartRef.current.timeScale().setVisibleLogicalRange(range)
-          }
-        }
-        
-        chartRef.current.timeScale().subscribeVisibleLogicalRangeChange(syncTimeScale)
-        
-        return () => {
-          chartRef.current?.timeScale().unsubscribeVisibleLogicalRangeChange(syncTimeScale)
-          rsiChart.remove()
-          rsiChartRef.current = null
-          rsiSeriesRef.current = null
-        }
-      }
-      
-      return () => {
-        rsiChart.remove()
-        rsiChartRef.current = null
-        rsiSeriesRef.current = null
-      }
-    },
-    [theme, height, rsi, preprocessLineData]
-  )
-
-  const initMacdChart = useCallback(
-    (el: HTMLDivElement) => {
-      const macdChart = createChart(el, {
-        width: el.clientWidth,
-        height: height * 0.25,
-        layout: {
-          background: { color: theme === 'dark' ? '#1e1e1e' : '#ffffff' },
-          textColor: theme === 'dark' ? '#d1d5db' : '#111827',
-          fontFamily: 'Inter, sans-serif',
-        },
-        grid: {
-          vertLines: { color: theme === 'dark' ? '#2f3338' : '#e0e0e0' },
-          horzLines: { color: theme === 'dark' ? '#2f3338' : '#e0e0e0' },
-        },
-        rightPriceScale: { 
-          borderColor: theme === 'dark' ? '#2f3338' : '#e0e0e0',
-          scaleMargins: {
-            top: 0.1,
-            bottom: 0.1,
-          }
-        },
-        timeScale: { 
-          borderColor: theme === 'dark' ? '#2f3338' : '#e0e0e0', 
-          timeVisible: true,
-          secondsVisible: false,
-        },
-        crosshair: {
-          mode: CrosshairMode.Normal,
-          vertLine: { 
-            labelVisible: true,
-          },
-          horzLine: { 
-            labelVisible: true,
-          }
-        },
-      })
-
-      macdChartRef.current = macdChart
-      macdSeriesRef.current = macdChart.addLineSeries({
-        color: '#2962FF',
-        lineWidth: 2,
-        title: 'MACD',
-        priceLineVisible: false,
-        lastValueVisible: true,
-      })
-      
-      signalSeriesRef.current = macdChart.addLineSeries({
-        color: '#FF6D00',
-        lineWidth: 2,
-        title: 'Signal',
-        priceLineVisible: false,
-        lastValueVisible: true,
-      })
-      
-      // MACDヒストグラムの追加
-      histogramSeriesRef.current = macdChart.addHistogramSeries({
-        color: '#26a69a',
-        priceFormat: { type: 'price' },
-        priceScaleId: 'right',
-        priceLineVisible: false,
-        lastValueVisible: false,
-      })
-
-      // データの設定
-      if (macdSeriesRef.current && macd && macd.length > 0) {
-        macdSeriesRef.current.setData(preprocessLineData(macd as LineData[]))
-      } else if (macdSeriesRef.current) {
-        // データがない場合でもグラフを表示するためのダミーデータ
-        macdSeriesRef.current.setData([{ time: Math.floor(Date.now() / 1000) as UTCTimestamp, value: 0 }])
-      }
-      
-      if (signalSeriesRef.current && signalData && signalData.length > 0) {
-        signalSeriesRef.current.setData(preprocessLineData(signalData as LineData[]))
-      } else if (signalSeriesRef.current) {
-        // データがない場合でもグラフを表示するためのダミーデータ
-        signalSeriesRef.current.setData([{ time: Math.floor(Date.now() / 1000) as UTCTimestamp, value: 0 }])
-      }
-      
-      // ヒストグラムデータの設定
-      if (histogramSeriesRef.current && macd && macd.length > 0 && signalData && signalData.length > 0) {
-        // MACDとシグナルの差分を計算してヒストグラムデータを生成
-        const rawHistogramData = macd.map((item, index) => {
-          if (index < signalData.length) {
-            const macdValue = (item as LineData).value as number;
-            const signalValue = (signalData[index] as LineData).value as number;
-            const diff = macdValue - signalValue;
-            
-            return {
-              time: (item as LineData).time,
-              value: diff,
-              color: diff >= 0 ? '#26a69a' : '#ef5350'
-            };
-          }
-          return null;
-        }).filter(item => item !== null) as HistogramData[];
-        
-        // タイムスタンプの重複を取り除く処理
-        const timeMap = new Map<number, HistogramData>();
-        
-        // タイムスタンプを数値化する関数
-        const getTimeAsNumber = (time: unknown): number => {
-          if (typeof time === 'number') return time;
-          if (typeof time === 'object' && time !== null && 'valueOf' in time) {
-            return (time as any).valueOf();
-          }
-          return 0;
-        };
-        
-        // 重複するタイムスタンプのデータを除去（最初のエントリのみ保持）
-        rawHistogramData.forEach(item => {
-          const timeKey = getTimeAsNumber(item.time);
-          if (!timeMap.has(timeKey)) {
-            timeMap.set(timeKey, item);
-          }
-        });
-        
-        // Map の値を配列に変換して時間順にソート
-        const uniqueHistogramData = Array.from(timeMap.values())
-          .sort((a, b) => {
-            const timeA = getTimeAsNumber(a.time);
-            const timeB = getTimeAsNumber(b.time);
-            return timeA - timeB;
-          });
-        
-        // 最終確認：隣接するタイムスタンプが同じでないことを確認
-        const finalHistogramData: HistogramData[] = [];
-        let prevTime: number | null = null;
-        
-        for (const item of uniqueHistogramData) {
-          const currentTime = getTimeAsNumber(item.time);
-          if (prevTime !== currentTime) {
-            finalHistogramData.push(item);
-            prevTime = currentTime;
-          }
-        }
-        
-        histogramSeriesRef.current.setData(finalHistogramData);
-      }
-
-      // メインチャートとの同期
-      if (chartRef.current) {
-        // 時間軸の同期
-        const syncTimeScale = (range: any) => {
-          if (macdChartRef.current && range !== null) {
-            macdChartRef.current.timeScale().setVisibleLogicalRange(range);
-          }
-        };
-        
-        chartRef.current.timeScale().subscribeVisibleLogicalRangeChange(syncTimeScale);
-        
-        return () => {
-          chartRef.current?.timeScale().unsubscribeVisibleLogicalRangeChange(syncTimeScale);
-          macdChart.remove();
-          macdChartRef.current = null;
-          macdSeriesRef.current = null;
-          signalSeriesRef.current = null;
-          histogramSeriesRef.current = null;
-        };
-      }
-      
-      return () => {
-        macdChart.remove();
-        macdChartRef.current = null;
-        macdSeriesRef.current = null;
-        signalSeriesRef.current = null;
-        histogramSeriesRef.current = null;
-      };
-    },
-    [theme, height, macd, signalData, preprocessLineData]
-  )
-  
-  // サブパネルの高さを調整（メインチャートより小さく）
-  const subPanelHeight = height * 0.25
-  
-  // メインチャートの高さを調整（サブパネルの表示状態に応じて）
-  // インジケーターパネルを外部で表示するため、メインチャートでは考慮しない
-  const mainChartHeight = height
+  const subHeight = height * 0.25
 
   return (
     <div className={className}>
-      {/* 垂直方向のフレックスコンテナ */}
       <div className="flex flex-col space-y-4">
-        {/* メインチャート */}
-        <div 
-          ref={containerRef} 
-          className="w-full rounded-md overflow-hidden border border-border" 
-          style={{ height: mainChartHeight }} 
-          data-testid="chart-container" 
-        />
-        
-        {/* インジケーターパネルはメインページで表示するため、ここでは表示しない */}
+        <div ref={containerRef} className="w-full rounded-md overflow-hidden border border-border" style={{ height }} data-testid="chart-container" />
+        {indicators.rsi && (
+          <RsiPanel data={rsi} chart={chartRef.current} height={subHeight} onClose={() => onIndicatorsChange?.({ ...indicators, rsi: false })} />
+        )}
+        {indicators.macd && (
+          <MacdPanel macd={macd} signal={signal} chart={chartRef.current} height={subHeight} onClose={() => onIndicatorsChange?.({ ...indicators, macd: false })} />
+        )}
       </div>
     </div>
   )

--- a/src/components/chart/MacdPanel.tsx
+++ b/src/components/chart/MacdPanel.tsx
@@ -1,0 +1,150 @@
+'use client'
+import { useRef, useCallback } from 'react'
+import { createChart, IChartApi, ISeriesApi, LineData, HistogramData, UTCTimestamp, CrosshairMode } from 'lightweight-charts'
+import IndicatorPanel from './IndicatorPanel'
+import useChartTheme from '@/hooks/use-chart-theme'
+import { preprocessLineData } from '@/lib/chart-utils'
+
+interface MacdPanelProps {
+  macd: LineData[]
+  signal: LineData[]
+  chart: IChartApi | null
+  height: number
+  onClose?: () => void
+}
+
+/**
+ * MACDパネルコンポーネント
+ */
+export default function MacdPanel({ macd, signal, chart, height, onClose }: MacdPanelProps) {
+  const colors = useChartTheme()
+  const chartRef = useRef<IChartApi | null>(null)
+  const macdRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const signalRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const histRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+
+  const initChart = useCallback((el: HTMLDivElement) => {
+    const macdChart = createChart(el, {
+      width: el.clientWidth,
+      height,
+      layout: {
+        background: { color: colors.background },
+        textColor: colors.text,
+        fontFamily: 'Inter, sans-serif'
+      },
+      grid: {
+        vertLines: { color: colors.grid },
+        horzLines: { color: colors.grid }
+      },
+      rightPriceScale: {
+        borderColor: colors.grid,
+        scaleMargins: { top: 0.1, bottom: 0.1 }
+      },
+      timeScale: {
+        borderColor: colors.grid,
+        timeVisible: true,
+        secondsVisible: false
+      },
+      crosshair: {
+        mode: CrosshairMode.Normal,
+        vertLine: { labelVisible: true },
+        horzLine: { labelVisible: true }
+      }
+    })
+
+    chartRef.current = macdChart
+    macdRef.current = macdChart.addLineSeries({
+      color: '#2962FF',
+      lineWidth: 2,
+      title: 'MACD',
+      priceLineVisible: false,
+      lastValueVisible: true
+    })
+    signalRef.current = macdChart.addLineSeries({
+      color: '#FF6D00',
+      lineWidth: 2,
+      title: 'Signal',
+      priceLineVisible: false,
+      lastValueVisible: true
+    })
+    histRef.current = macdChart.addHistogramSeries({
+      color: '#26a69a',
+      priceFormat: { type: 'price' },
+      priceScaleId: 'right',
+      priceLineVisible: false,
+      lastValueVisible: false
+    })
+
+    if (macdRef.current) {
+      if (macd && macd.length > 0) {
+        macdRef.current.setData(preprocessLineData(macd))
+      } else {
+        macdRef.current.setData([{ time: Math.floor(Date.now()/1000) as UTCTimestamp, value: 0 }])
+      }
+    }
+    if (signalRef.current) {
+      if (signal && signal.length > 0) {
+        signalRef.current.setData(preprocessLineData(signal))
+      } else {
+        signalRef.current.setData([{ time: Math.floor(Date.now()/1000) as UTCTimestamp, value: 0 }])
+      }
+    }
+
+    if (histRef.current && macd && signal && macd.length > 0 && signal.length > 0) {
+      const raw: HistogramData[] = macd.map((m, idx) => {
+        if (idx < signal.length) {
+          const diff = (m.value as number) - (signal[idx].value as number)
+          return { time: m.time, value: diff, color: diff >= 0 ? '#26a69a' : '#ef5350' }
+        }
+        return null
+      }).filter(Boolean) as HistogramData[]
+
+      const timeMap = new Map<number, HistogramData>()
+      const getNum = (t: unknown) => typeof t === 'number' ? t : (t as any).valueOf()
+      raw.forEach(item => {
+        const key = getNum(item.time)
+        if (!timeMap.has(key)) timeMap.set(key, item)
+      })
+      const unique = Array.from(timeMap.values()).sort((a,b) => getNum(a.time)-getNum(b.time))
+      const final: HistogramData[] = []
+      let prev: number | null = null
+      unique.forEach(it => {
+        const cur = getNum(it.time)
+        if (cur !== prev) {
+          final.push(it)
+          prev = cur
+        }
+      })
+      histRef.current.setData(final)
+    }
+
+    if (chart) {
+      const sync = (range: any) => {
+        if (chartRef.current && range !== null) {
+          chartRef.current.timeScale().setVisibleLogicalRange(range)
+        }
+      }
+      chart.timeScale().subscribeVisibleLogicalRangeChange(sync)
+      return () => {
+        chart.timeScale().unsubscribeVisibleLogicalRangeChange(sync)
+        macdChart.remove()
+        chartRef.current = null
+        macdRef.current = null
+        signalRef.current = null
+        histRef.current = null
+      }
+    }
+
+    return () => {
+      macdChart.remove()
+      chartRef.current = null
+      macdRef.current = null
+      signalRef.current = null
+      histRef.current = null
+    }
+  }, [colors, height, macd, signal, chart])
+
+  return (
+    <IndicatorPanel title="MACD" height={height} onClose={onClose} initChart={initChart} />
+  )
+}

--- a/src/components/chart/RsiPanel.tsx
+++ b/src/components/chart/RsiPanel.tsx
@@ -1,0 +1,120 @@
+'use client'
+import { useRef, useCallback } from 'react'
+import { createChart, IChartApi, ISeriesApi, LineData, UTCTimestamp, CrosshairMode } from 'lightweight-charts'
+import IndicatorPanel from './IndicatorPanel'
+import useChartTheme from '@/hooks/use-chart-theme'
+import { preprocessLineData } from '@/lib/chart-utils'
+
+interface RsiPanelProps {
+  data: LineData[]
+  chart: IChartApi | null
+  height: number
+  onClose?: () => void
+}
+
+/**
+ * RSIパネルコンポーネント
+ */
+export default function RsiPanel({ data, chart, height, onClose }: RsiPanelProps) {
+  const colors = useChartTheme()
+  const chartRef = useRef<IChartApi | null>(null)
+  const seriesRef = useRef<ISeriesApi<'Line'> | null>(null)
+
+  const initChart = useCallback((el: HTMLDivElement) => {
+    const rsiChart = createChart(el, {
+      width: el.clientWidth,
+      height,
+      layout: {
+        background: { color: colors.background },
+        textColor: colors.text,
+        fontFamily: 'Inter, sans-serif'
+      },
+      grid: {
+        vertLines: { color: colors.grid },
+        horzLines: { color: colors.grid }
+      },
+      rightPriceScale: {
+        borderColor: colors.grid,
+        scaleMargins: { top: 0.1, bottom: 0.1 }
+      },
+      timeScale: {
+        borderColor: colors.grid,
+        timeVisible: true,
+        secondsVisible: false
+      },
+      crosshair: {
+        mode: CrosshairMode.Normal,
+        vertLine: { labelVisible: true },
+        horzLine: { labelVisible: true }
+      }
+    })
+
+    chartRef.current = rsiChart
+    seriesRef.current = rsiChart.addLineSeries({
+      color: '#2962FF',
+      lineWidth: 2,
+      title: 'RSI',
+      priceLineVisible: false,
+      lastValueVisible: true
+    })
+
+    const overSoldLine = rsiChart.addLineSeries({
+      color: 'rgba(239, 83, 80, 0.5)',
+      lineWidth: 1,
+      lineStyle: 1,
+      priceLineVisible: false,
+      lastValueVisible: false
+    })
+    const overBoughtLine = rsiChart.addLineSeries({
+      color: 'rgba(38, 166, 154, 0.5)',
+      lineWidth: 1,
+      lineStyle: 1,
+      priceLineVisible: false,
+      lastValueVisible: false
+    })
+
+    const timeFrom = Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30
+    const timeTo = Math.floor(Date.now() / 1000) + 60 * 60 * 24
+    overSoldLine.setData([
+      { time: timeFrom as UTCTimestamp, value: 30 },
+      { time: timeTo as UTCTimestamp, value: 30 }
+    ])
+    overBoughtLine.setData([
+      { time: timeFrom as UTCTimestamp, value: 70 },
+      { time: timeTo as UTCTimestamp, value: 70 }
+    ])
+
+    if (seriesRef.current) {
+      if (data && data.length > 0) {
+        seriesRef.current.setData(preprocessLineData(data))
+      } else {
+        seriesRef.current.setData([{ time: Math.floor(Date.now() / 1000) as UTCTimestamp, value: 50 }])
+      }
+    }
+
+    if (chart) {
+      const sync = (range: any) => {
+        if (chartRef.current && range !== null) {
+          chartRef.current.timeScale().setVisibleLogicalRange(range)
+        }
+      }
+      chart.timeScale().subscribeVisibleLogicalRangeChange(sync)
+      return () => {
+        chart.timeScale().unsubscribeVisibleLogicalRangeChange(sync)
+        rsiChart.remove()
+        chartRef.current = null
+        seriesRef.current = null
+      }
+    }
+
+    return () => {
+      rsiChart.remove()
+      chartRef.current = null
+      seriesRef.current = null
+    }
+  }, [colors, height, data, chart])
+
+  return (
+    <IndicatorPanel title="RSI" height={height} onClose={onClose} initChart={initChart} />
+  )
+}

--- a/src/hooks/use-chart-theme.ts
+++ b/src/hooks/use-chart-theme.ts
@@ -1,0 +1,34 @@
+import { useTheme } from 'next-themes'
+import { useMemo } from 'react'
+
+export interface ChartTheme {
+  background: string
+  text: string
+  grid: string
+  crosshair: string
+  upColor: string
+  downColor: string
+  volume: string
+}
+
+/**
+ * チャートのテーマカラーを返すフック
+ * @returns テーマに応じたカラー設定
+ */
+export function useChartTheme(): ChartTheme {
+  const { theme = 'light' } = useTheme()
+  return useMemo(() => {
+    const isDark = theme === 'dark'
+    return {
+      background: isDark ? '#1e1e1e' : '#ffffff',
+      text: isDark ? '#d1d5db' : '#111827',
+      grid: isDark ? '#2f3338' : '#e0e0e0',
+      crosshair: isDark ? '#d1d5db' : '#111827',
+      upColor: '#26a69a',
+      downColor: '#ef5350',
+      volume: '#4b5563'
+    }
+  }, [theme])
+}
+
+export default useChartTheme

--- a/src/hooks/use-line-series.ts
+++ b/src/hooks/use-line-series.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react'
+import type { IChartApi, ISeriesApi, LineData } from 'lightweight-charts'
+import { preprocessLineData } from '@/lib/chart-utils'
+
+interface UseLineSeriesParams {
+  chart: IChartApi | null
+  ref: React.MutableRefObject<ISeriesApi<'Line'> | null>
+  enabled: boolean
+  options: Parameters<IChartApi['addLineSeries']>[0]
+  data: LineData[]
+}
+
+/**
+ * ラインシリーズの生成と削除を管理するフック
+ */
+export function useLineSeries({
+  chart,
+  ref,
+  enabled,
+  options,
+  data
+}: UseLineSeriesParams) {
+  useEffect(() => {
+    if (!chart) return
+
+    if (enabled) {
+      if (!ref.current) {
+        ref.current = chart.addLineSeries(options)
+      }
+      const processed = preprocessLineData(data)
+      if (ref.current && processed.length > 0) {
+        ref.current.setData(processed)
+      }
+    } else if (ref.current) {
+      try {
+        chart.removeSeries(ref.current)
+      } catch (e) {
+        console.error('Error removing series:', e)
+      }
+      ref.current = null
+    }
+  }, [chart, ref, enabled, options, data])
+}
+
+export default useLineSeries

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -1,0 +1,89 @@
+import type { LineData } from 'lightweight-charts'
+
+/**
+ * ラインチャートデータをソート・重複除去する
+ * @param arr - LineData 配列
+ * @returns 前処理されたデータ
+ */
+export function preprocessLineData(arr: LineData[]): LineData[] {
+  if (!arr || arr.length === 0) return []
+
+  const getNumTime = (t: LineData['time']): number => {
+    if (typeof t === 'number') return t
+    if (typeof t === 'object' && t !== null && 'year' in t && 'month' in t && 'day' in t) {
+      const bd = t as { year: number; month: number; day: number }
+      return Math.floor(new Date(bd.year, bd.month - 1, bd.day).getTime() / 1000)
+    }
+    if (typeof t === 'object' && t !== null && 'valueOf' in t) {
+      return (t as any).valueOf()
+    }
+    return Math.floor(new Date(t as unknown as string).getTime() / 1000)
+  }
+
+  const timeMap = new Map<number, LineData>()
+  arr.forEach(item => {
+    const timeKey = getNumTime(item.time)
+    if (!timeMap.has(timeKey)) {
+      timeMap.set(timeKey, item)
+    }
+  })
+
+  const uniqueData = Array.from(timeMap.values())
+  const sortedData = uniqueData.sort((a, b) => {
+    const timeA = getNumTime(a.time)
+    const timeB = getNumTime(b.time)
+    return timeA - timeB
+  })
+
+  const finalData: LineData[] = []
+  let prevTime: number | null = null
+  for (const item of sortedData) {
+    const currentTime = getNumTime(item.time)
+    if (prevTime !== currentTime) {
+      finalData.push(item)
+      prevTime = currentTime
+    }
+  }
+
+  return finalData
+}
+
+/**
+ * タイムスタンプをキーとした系列データの重複除去
+ * @param data - シリーズデータ
+ * @param timeToNumber - 時間変換関数
+ * @returns 処理済みデータ
+ */
+export function processTimeSeriesData<T extends { time: unknown }>(
+  data: T[],
+  timeToNumber: (time: unknown) => number
+): T[] {
+  if (!data || data.length === 0) return []
+
+  const timeMap = new Map<number, T>()
+  data.forEach(item => {
+    const timeKey = timeToNumber(item.time)
+    if (!timeMap.has(timeKey)) {
+      timeMap.set(timeKey, item)
+    }
+  })
+
+  const uniqueData = Array.from(timeMap.values())
+  const sortedData = uniqueData.sort((a, b) => {
+    const timeA = timeToNumber(a.time)
+    const timeB = timeToNumber(b.time)
+    return timeA - timeB
+  })
+
+  const finalData: T[] = []
+  let prevTime: number | null = null
+  for (const item of sortedData) {
+    const currentTime = timeToNumber(item.time)
+    if (prevTime !== currentTime) {
+      finalData.push(item)
+      prevTime = currentTime
+    }
+  }
+
+  return finalData
+}

--- a/src/tests/components/MacdPanel.test.tsx
+++ b/src/tests/components/MacdPanel.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import MacdPanel from '@/components/chart/MacdPanel'
+
+jest.mock('lightweight-charts', () => ({
+  createChart: () => ({
+    addLineSeries: () => ({ setData: jest.fn() }),
+    addHistogramSeries: () => ({ setData: jest.fn() }),
+    timeScale: () => ({ setVisibleLogicalRange: jest.fn() }),
+    remove: jest.fn()
+  }),
+  CrosshairMode: { Normal: 0 }
+}))
+
+jest.mock('@/components/chart/IndicatorPanel', () => ({
+  __esModule: true,
+  default: ({ initChart, title }: any) => {
+    const ref = { current: document.createElement('div') } as any
+    if (initChart) initChart(ref.current)
+    return <div data-testid={`${title.toLowerCase()}-panel`} />
+  }
+}))
+
+describe('MacdPanel', () => {
+  it('renders panel element', () => {
+    render(<MacdPanel macd={[]} signal={[]} chart={null} height={100} />)
+    expect(screen.getByTestId('macd-panel')).toBeInTheDocument()
+  })
+})

--- a/src/tests/components/RsiPanel.test.tsx
+++ b/src/tests/components/RsiPanel.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import RsiPanel from '@/components/chart/RsiPanel'
+
+jest.mock('lightweight-charts', () => ({
+  createChart: () => ({
+    addLineSeries: () => ({ setData: jest.fn() }),
+    timeScale: () => ({ setVisibleLogicalRange: jest.fn() }),
+    remove: jest.fn()
+  }),
+  CrosshairMode: { Normal: 0 }
+}))
+
+jest.mock('@/components/chart/IndicatorPanel', () => ({
+  __esModule: true,
+  default: ({ initChart, title }: any) => {
+    const ref = { current: document.createElement('div') } as any
+    if (initChart) initChart(ref.current)
+    return <div data-testid={`${title.toLowerCase()}-panel`} />
+  }
+}))
+
+describe('RsiPanel', () => {
+  it('renders panel element', () => {
+    render(<RsiPanel data={[]} chart={null} height={100} />)
+    expect(screen.getByTestId('rsi-panel')).toBeInTheDocument()
+  })
+})

--- a/src/tests/hooks/use-line-series.test.ts
+++ b/src/tests/hooks/use-line-series.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react'
+import { useLineSeries } from '@/hooks/use-line-series'
+import { preprocessLineData } from '@/lib/chart-utils'
+import type { IChartApi, ISeriesApi, LineData } from 'lightweight-charts'
+
+jest.mock('@/lib/chart-utils', () => ({
+  preprocessLineData: jest.fn((d: LineData[]) => d)
+}))
+
+describe('useLineSeries', () => {
+  it('adds and removes line series based on enabled flag', () => {
+    const setData = jest.fn()
+    const series: Partial<ISeriesApi<'Line'>> = { setData }
+    const addLineSeries = jest.fn(() => series as ISeriesApi<'Line'>)
+    const removeSeries = jest.fn()
+    const chart = { addLineSeries, removeSeries } as unknown as IChartApi
+    const ref = { current: null } as React.MutableRefObject<ISeriesApi<'Line'> | null>
+
+    const { rerender } = renderHook(({ enabled }) =>
+      useLineSeries({ chart, ref, enabled, options: {}, data: [{ time: 1, value: 2 }] })
+    , { initialProps: { enabled: true } })
+
+    expect(addLineSeries).toHaveBeenCalled()
+    expect(setData).toHaveBeenCalled()
+
+    rerender({ enabled: false })
+    expect(removeSeries).toHaveBeenCalledWith(series)
+    expect(ref.current).toBeNull()
+  })
+})

--- a/src/tests/lib/chart-utils.test.ts
+++ b/src/tests/lib/chart-utils.test.ts
@@ -1,0 +1,36 @@
+import { preprocessLineData, processTimeSeriesData } from '@/lib/chart-utils'
+import type { LineData } from 'lightweight-charts'
+
+describe('chart-utils', () => {
+  describe('preprocessLineData', () => {
+    it('sorts and deduplicates line data', () => {
+      const input: LineData[] = [
+        { time: 3, value: 1 },
+        { time: 1, value: 2 },
+        { time: 2, value: 3 },
+        { time: 2, value: 4 }
+      ]
+      const result = preprocessLineData(input)
+      expect(result).toEqual([
+        { time: 1, value: 2 },
+        { time: 2, value: 3 },
+        { time: 3, value: 1 }
+      ])
+    })
+  })
+
+  describe('processTimeSeriesData', () => {
+    it('processes generic series data', () => {
+      const input = [
+        { time: 2, foo: 'a' },
+        { time: 1, foo: 'b' },
+        { time: 1, foo: 'c' }
+      ]
+      const result = processTimeSeriesData(input, t => t as number)
+      expect(result).toEqual([
+        { time: 1, foo: 'b' },
+        { time: 2, foo: 'a' }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add `use-chart-theme` hook for theme based chart colors
- move data helpers to `chart-utils`
- add `use-line-series` hook
- create `RsiPanel` and `MacdPanel` components using `IndicatorPanel`
- simplify `CandlestickChart` to orchestrate charts with new hooks
- add unit tests for new utilities and components

## Testing
- `pnpm test`