### PR TITLE
Add hook option to disable candlestick data fetch

### DIFF
--- a/src/components/chart/CandlestickChart.tsx
+++ b/src/components/chart/CandlestickChart.tsx
@@ -1,29 +1,36 @@
-'use client'
-import { createChart, CandlestickData, HistogramData, IChartApi, ISeriesApi, CrosshairMode } from 'lightweight-charts'
-import { useEffect, useRef } from 'react'
-import { Skeleton } from '@/components/ui/skeleton'
-import useChartTheme from '@/hooks/use-chart-theme'
-import useCandlestickData from '@/hooks/use-candlestick-data'
-import { processTimeSeriesData } from '@/lib/chart-utils'
-import useLineSeries from '@/hooks/use-line-series'
-import RsiPanel from './RsiPanel'
-import MacdPanel from './MacdPanel'
+"use client";
+import {
+  createChart,
+  CandlestickData,
+  HistogramData,
+  IChartApi,
+  ISeriesApi,
+  CrosshairMode,
+} from "lightweight-charts";
+import { useEffect, useRef } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import useChartTheme from "@/hooks/use-chart-theme";
+import useCandlestickData from "@/hooks/use-candlestick-data";
+import { processTimeSeriesData } from "@/lib/chart-utils";
+import useLineSeries from "@/hooks/use-line-series";
+import RsiPanel from "./RsiPanel";
+import MacdPanel from "./MacdPanel";
 
 interface IndicatorOptions {
-  ma: boolean
-  rsi: boolean
-  macd?: boolean
-  boll?: boolean
+  ma: boolean;
+  rsi: boolean;
+  macd?: boolean;
+  boll?: boolean;
 }
 
 interface CandlestickChartProps {
-  className?: string
-  height?: number
-  symbol?: string
-  interval?: string
-  useApi?: boolean
-  indicators?: IndicatorOptions
-  onIndicatorsChange?: (value: IndicatorOptions) => void
+  className?: string;
+  height?: number;
+  symbol?: string;
+  interval?: string;
+  useApi?: boolean;
+  indicators?: IndicatorOptions;
+  onIndicatorsChange?: (value: IndicatorOptions) => void;
 }
 
 /**
@@ -32,123 +39,214 @@ interface CandlestickChartProps {
 export default function CandlestickChart({
   className,
   height = 400,
-  symbol: initialSymbol = 'BTCUSDT',
-  interval: initialInterval = '1m',
+  symbol: initialSymbol = "BTCUSDT",
+  interval: initialInterval = "1m",
   useApi = false,
   indicators = { ma: false, rsi: false, macd: false, boll: false },
-  onIndicatorsChange
+  onIndicatorsChange,
 }: CandlestickChartProps) {
-  const colors = useChartTheme()
-  const containerRef = useRef<HTMLDivElement>(null)
-  const chartRef = useRef<IChartApi | null>(null)
-  const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
-  const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null)
-  const maRef = useRef<ISeriesApi<'Line'> | null>(null)
-  const bollUpperRef = useRef<ISeriesApi<'Line'> | null>(null)
-  const bollLowerRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const colors = useChartTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const candleRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
+  const volumeRef = useRef<ISeriesApi<"Histogram"> | null>(null);
+  const maRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const bollUpperRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const bollLowerRef = useRef<ISeriesApi<"Line"> | null>(null);
 
-  const { candles = [], volumes = [], ma = [], rsi = [], macd = [], signal = [], bollUpper = [], bollLower = [], loading, error } = useCandlestickData(initialSymbol, initialInterval)
+  const {
+    candles = [],
+    volumes = [],
+    ma = [],
+    rsi = [],
+    macd = [],
+    signal = [],
+    bollUpper = [],
+    bollLower = [],
+    loading,
+    error,
+  } = useCandlestickData(initialSymbol, initialInterval, { enabled: useApi });
 
-  useLineSeries({ chart: chartRef.current, ref: maRef, enabled: indicators.ma, options: { color: '#f59e0b', lineWidth: 2, priceLineVisible: false }, data: ma })
-  useLineSeries({ chart: chartRef.current, ref: bollUpperRef, enabled: indicators.boll, options: { color: '#a855f7', lineWidth: 1, priceLineVisible: false }, data: bollUpper })
-  useLineSeries({ chart: chartRef.current, ref: bollLowerRef, enabled: indicators.boll, options: { color: '#a855f7', lineWidth: 1, priceLineVisible: false }, data: bollLower })
+  useLineSeries({
+    chart: chartRef.current,
+    ref: maRef,
+    enabled: indicators.ma,
+    options: { color: "#f59e0b", lineWidth: 2, priceLineVisible: false },
+    data: ma,
+  });
+  useLineSeries({
+    chart: chartRef.current,
+    ref: bollUpperRef,
+    enabled: indicators.boll,
+    options: { color: "#a855f7", lineWidth: 1, priceLineVisible: false },
+    data: bollUpper,
+  });
+  useLineSeries({
+    chart: chartRef.current,
+    ref: bollLowerRef,
+    enabled: indicators.boll,
+    options: { color: "#a855f7", lineWidth: 1, priceLineVisible: false },
+    data: bollLower,
+  });
 
   useEffect(() => {
-    if (!containerRef.current) return
+    if (!containerRef.current) return;
     const chart = createChart(containerRef.current, {
       width: containerRef.current.clientWidth,
       height,
-      layout: { background: { color: colors.background }, textColor: colors.text },
-      grid: { vertLines: { color: colors.grid }, horzLines: { color: colors.grid } },
+      layout: {
+        background: { color: colors.background },
+        textColor: colors.text,
+      },
+      grid: {
+        vertLines: { color: colors.grid },
+        horzLines: { color: colors.grid },
+      },
       crosshair: {
         mode: CrosshairMode.Normal,
-        vertLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background },
-        horzLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background }
+        vertLine: {
+          color: colors.crosshair,
+          labelVisible: true,
+          labelBackgroundColor: colors.background,
+        },
+        horzLine: {
+          color: colors.crosshair,
+          labelVisible: true,
+          labelBackgroundColor: colors.background,
+        },
       },
       rightPriceScale: {
         borderColor: colors.grid,
         borderVisible: true,
-        scaleMargins: { top: 0.1, bottom: 0.2 }
+        scaleMargins: { top: 0.1, bottom: 0.2 },
       },
-      timeScale: { borderColor: colors.grid, timeVisible: true }
-    })
-    chartRef.current = chart
+      timeScale: { borderColor: colors.grid, timeVisible: true },
+    });
+    chartRef.current = chart;
     candleRef.current = chart.addCandlestickSeries({
       upColor: colors.upColor,
       downColor: colors.downColor,
       wickUpColor: colors.upColor,
       wickDownColor: colors.downColor,
-      borderVisible: false
-    })
-    volumeRef.current = chart.addHistogramSeries({ priceFormat: { type: 'volume' }, priceScaleId: 'vol', color: colors.volume })
-    chart.priceScale('vol').applyOptions({ scaleMargins: { top: 0.9, bottom: 0 } })
+      borderVisible: false,
+    });
+    volumeRef.current = chart.addHistogramSeries({
+      priceFormat: { type: "volume" },
+      priceScaleId: "vol",
+      color: colors.volume,
+    });
+    chart
+      .priceScale("vol")
+      .applyOptions({ scaleMargins: { top: 0.9, bottom: 0 } });
     const handleResize = () => {
       if (containerRef.current && chartRef.current) {
-        chartRef.current.resize(containerRef.current.clientWidth, height)
+        chartRef.current.resize(containerRef.current.clientWidth, height);
       }
-    }
-    window.addEventListener('resize', handleResize)
+    };
+    window.addEventListener("resize", handleResize);
     return () => {
-      window.removeEventListener('resize', handleResize)
-      chart.remove()
-      chartRef.current = null
-    }
-  }, [colors, height])
+      window.removeEventListener("resize", handleResize);
+      chart.remove();
+      chartRef.current = null;
+    };
+  }, [colors, height]);
 
   useEffect(() => {
-    if (!chartRef.current) return
+    if (!chartRef.current) return;
     chartRef.current.applyOptions({
-      layout: { background: { color: colors.background }, textColor: colors.text },
-      grid: { vertLines: { color: colors.grid }, horzLines: { color: colors.grid } },
+      layout: {
+        background: { color: colors.background },
+        textColor: colors.text,
+      },
+      grid: {
+        vertLines: { color: colors.grid },
+        horzLines: { color: colors.grid },
+      },
       crosshair: {
         mode: CrosshairMode.Normal,
-        vertLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background },
-        horzLine: { color: colors.crosshair, labelVisible: true, labelBackgroundColor: colors.background }
+        vertLine: {
+          color: colors.crosshair,
+          labelVisible: true,
+          labelBackgroundColor: colors.background,
+        },
+        horzLine: {
+          color: colors.crosshair,
+          labelVisible: true,
+          labelBackgroundColor: colors.background,
+        },
       },
       rightPriceScale: { borderColor: colors.grid },
-      timeScale: { borderColor: colors.grid }
-    })
+      timeScale: { borderColor: colors.grid },
+    });
     candleRef.current?.applyOptions({
       upColor: colors.upColor,
       downColor: colors.downColor,
       wickUpColor: colors.upColor,
       wickDownColor: colors.downColor,
-      borderVisible: false
-    })
-    volumeRef.current?.applyOptions({ color: colors.volume })
-  }, [colors])
+      borderVisible: false,
+    });
+    volumeRef.current?.applyOptions({ color: colors.volume });
+  }, [colors]);
 
   useEffect(() => {
     const toNum = (t: unknown): number => {
-      if (typeof t === 'number') return t
-      if (typeof t === 'string') return Math.floor(new Date(t).getTime() / 1000)
-      if (typeof t === 'object' && t !== null && 'valueOf' in t) return (t as any).valueOf()
-      return 0
-    }
+      if (typeof t === "number") return t;
+      if (typeof t === "string")
+        return Math.floor(new Date(t).getTime() / 1000);
+      if (typeof t === "object" && t !== null && "valueOf" in t)
+        return (t as any).valueOf();
+      return 0;
+    };
     if (candleRef.current && candles.length > 0) {
-      candleRef.current.setData(processTimeSeriesData<CandlestickData>(candles, toNum))
+      candleRef.current.setData(
+        processTimeSeriesData<CandlestickData>(candles, toNum),
+      );
     }
     if (volumeRef.current && volumes.length > 0) {
-      volumeRef.current.setData(processTimeSeriesData<HistogramData>(volumes, toNum))
+      volumeRef.current.setData(
+        processTimeSeriesData<HistogramData>(volumes, toNum),
+      );
     }
-  }, [candles, volumes])
+  }, [candles, volumes]);
 
-  if (loading && useApi) return <Skeleton data-testid="loading" className="w-full h-[300px]" />
-  if (error && useApi) return <div data-testid="error" className="text-center text-sm text-red-500">{error}</div>
+  if (loading && useApi)
+    return <Skeleton data-testid="loading" className="w-full h-[300px]" />;
+  if (error && useApi)
+    return (
+      <div data-testid="error" className="text-center text-sm text-red-500">
+        {error}
+      </div>
+    );
 
-  const subHeight = height * 0.25
+  const subHeight = height * 0.25;
 
   return (
     <div className={className}>
       <div className="flex flex-col space-y-4">
-        <div ref={containerRef} className="w-full rounded-md overflow-hidden border border-border" style={{ height }} data-testid="chart-container" />
+        <div
+          ref={containerRef}
+          className="w-full rounded-md overflow-hidden border border-border"
+          style={{ height }}
+          data-testid="chart-container"
+        />
         {indicators.rsi && (
-          <RsiPanel data={rsi} chart={chartRef.current} height={subHeight} onClose={() => onIndicatorsChange?.({ ...indicators, rsi: false })} />
+          <RsiPanel
+            data={rsi}
+            chart={chartRef.current}
+            height={subHeight}
+            onClose={() => onIndicatorsChange?.({ ...indicators, rsi: false })}
+          />
         )}
         {indicators.macd && (
-          <MacdPanel macd={macd} signal={signal} chart={chartRef.current} height={subHeight} onClose={() => onIndicatorsChange?.({ ...indicators, macd: false })} />
+          <MacdPanel
+            macd={macd}
+            signal={signal}
+            chart={chartRef.current}
+            height={subHeight}
+            onClose={() => onIndicatorsChange?.({ ...indicators, macd: false })}
+          />
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/chart/PriceChart.tsx
+++ b/src/components/chart/PriceChart.tsx
@@ -1,29 +1,28 @@
-'use client';
+"use client";
 
-import { createChart, UTCTimestamp, IChartApi, ISeriesApi } from 'lightweight-charts';
-import { useEffect, useRef, useState, useCallback } from 'react';
-import useBinanceSocket from '@/hooks/use-binance-socket';
-import { Card, CardContent } from '@/components/ui/card';
 import {
-  computeSMA,
-  computeRSI,
-  computeMACD,
-} from '@/lib/indicators';
-
+  createChart,
+  UTCTimestamp,
+  IChartApi,
+  ISeriesApi,
+} from "lightweight-charts";
+import { useEffect, useRef, useState, useCallback } from "react";
+import useBinanceSocket from "@/hooks/use-binance-socket";
+import { Card, CardContent } from "@/components/ui/card";
+import { computeSMA, computeRSI, computeMACD } from "@/lib/indicators";
 
 export default function PriceChart() {
   const containerRef = useRef<HTMLDivElement>(null);
   const priceData = useRef<number[]>([]);
   const chartRef = useRef<IChartApi | null>(null);
-  const priceSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
-  const maSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
-  const rsiSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
-  const macdSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+  const priceSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const maSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const rsiSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const macdSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
   const [lastPrice, setLastPrice] = useState<number | null>(null);
   const [priceChange, setPriceChange] = useState<number>(0);
-  const [initTime] = useState(Date.now());
   const { status: connectionStatus } = useBinanceSocket({
-    url: 'wss://stream.binance.com:9443/ws/btcusdt@trade',
+    url: "wss://stream.binance.com:9443/ws/btcusdt@trade",
     onMessage: useCallback((msg: any) => {
       const price = parseFloat(msg.p);
       const time = Math.floor(msg.T / 1000) as UTCTimestamp;
@@ -53,7 +52,8 @@ export default function PriceChart() {
         if (rsi !== null) rsiSeriesRef.current.update({ time, value: rsi });
 
         const macd = computeMACD(priceData.current);
-        if (macd !== null) macdSeriesRef.current.update({ time, value: macd.histogram });
+        if (macd !== null)
+          macdSeriesRef.current.update({ time, value: macd.histogram });
       }
     }, []),
   });
@@ -66,53 +66,53 @@ export default function PriceChart() {
 
     const chart = createChart(containerRef.current, {
       layout: {
-        background: { color: 'transparent' },
-        textColor: 'rgba(100, 100, 100, 0.9)',
+        background: { color: "transparent" },
+        textColor: "rgba(100, 100, 100, 0.9)",
       },
       grid: {
-        vertLines: { color: 'rgba(42, 46, 57, 0.2)' },
-        horzLines: { color: 'rgba(42, 46, 57, 0.2)' },
+        vertLines: { color: "rgba(42, 46, 57, 0.2)" },
+        horzLines: { color: "rgba(42, 46, 57, 0.2)" },
       },
-      timeScale: { 
-        timeVisible: true, 
+      timeScale: {
+        timeVisible: true,
         secondsVisible: true,
-        borderColor: 'rgba(42, 46, 57, 0.3)',
+        borderColor: "rgba(42, 46, 57, 0.3)",
       },
       rightPriceScale: {
-        borderColor: 'rgba(42, 46, 57, 0.3)',
+        borderColor: "rgba(42, 46, 57, 0.3)",
       },
       width,
       height: 380,
     });
-    
+
     chartRef.current = chart;
-    
-    const priceSeries = chart.addLineSeries({ 
-      color: '#22c55e', 
+
+    const priceSeries = chart.addLineSeries({
+      color: "#22c55e",
       lineWidth: 2,
       priceLineVisible: true,
     });
     priceSeriesRef.current = priceSeries;
-    
-    const maSeries = chart.addLineSeries({ 
-      color: '#f59e0b', 
+
+    const maSeries = chart.addLineSeries({
+      color: "#f59e0b",
       lineWidth: 2,
       priceLineVisible: false,
     });
     maSeriesRef.current = maSeries;
-    
+
     const rsiSeries = chart.addLineSeries({
-      color: '#3b82f6',
+      color: "#3b82f6",
       lineWidth: 1,
-      priceScaleId: 'right',
+      priceScaleId: "right",
       priceLineVisible: false,
     });
     rsiSeriesRef.current = rsiSeries;
 
     const macdSeries = chart.addLineSeries({
-      color: '#10b981',
+      color: "#10b981",
       lineWidth: 1,
-      priceScaleId: 'right',
+      priceScaleId: "right",
       priceLineVisible: false,
     });
     macdSeriesRef.current = macdSeries;
@@ -120,21 +120,18 @@ export default function PriceChart() {
     // Handle resize
     const handleResize = () => {
       if (containerRef.current && chartRef.current) {
-        chartRef.current.resize(
-          containerRef.current.clientWidth,
-          380
-        );
+        chartRef.current.resize(containerRef.current.clientWidth, 380);
       }
     };
-    
+
     // Add event listeners
-    window.addEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener("resize", handleResize);
 
       // クリーンアップ処理
-      
+
       if (chartRef.current) {
         chartRef.current.remove();
         chartRef.current = null;
@@ -154,20 +151,29 @@ export default function PriceChart() {
         <div>
           <div className="flex items-center">
             <span className="text-lg font-bold">BTC/USDT</span>
-            <span className={`ml-2 text-sm ${priceChange >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-              {priceChange >= 0 ? '+' : ''}{priceChange.toFixed(2)}%
+            <span
+              className={`ml-2 text-sm ${priceChange >= 0 ? "text-green-500" : "text-red-500"}`}
+            >
+              {priceChange >= 0 ? "+" : ""}
+              {priceChange.toFixed(2)}%
             </span>
             <span className="ml-2 text-xs">
-              {connectionStatus === 'connected' 
-                ? '🟢 接続中' 
-                : connectionStatus === 'connecting' 
-                  ? '🟡 接続中...' 
-                  : '🔴 未接続'}
+              {connectionStatus === "connected"
+                ? "🟢 接続中"
+                : connectionStatus === "connecting"
+                  ? "🟡 接続中..."
+                  : "🔴 未接続"}
             </span>
           </div>
           {lastPrice && (
-            <div className={`text-2xl font-bold ${priceChange >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-              ${lastPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            <div
+              className={`text-2xl font-bold ${priceChange >= 0 ? "text-green-500" : "text-red-500"}`}
+            >
+              $
+              {lastPrice.toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
             </div>
           )}
         </div>
@@ -175,14 +181,16 @@ export default function PriceChart() {
           ライブプライスフィード - Binance
         </div>
       </div>
-      <div 
-        ref={containerRef} 
-        className="w-full rounded-md overflow-hidden mb-2" 
+      <div
+        ref={containerRef}
+        className="w-full rounded-md overflow-hidden mb-2"
       />
       <div className="grid grid-cols-4 gap-2 text-xs mt-2">
         <div className="border rounded-md p-2">
           <div className="text-muted-foreground">14日SMA</div>
-          <div className="font-semibold text-amber-500">移動平均（オレンジ）</div>
+          <div className="font-semibold text-amber-500">
+            移動平均（オレンジ）
+          </div>
         </div>
         <div className="border rounded-md p-2">
           <div className="text-muted-foreground">14日RSI</div>
@@ -190,7 +198,9 @@ export default function PriceChart() {
         </div>
         <div className="border rounded-md p-2">
           <div className="text-muted-foreground">MACD</div>
-          <div className="font-semibold text-emerald-500">ヒストグラム（緑）</div>
+          <div className="font-semibold text-emerald-500">
+            ヒストグラム（緑）
+          </div>
         </div>
         <div className="border rounded-md p-2">
           <div className="text-muted-foreground">時間スケール</div>

--- a/src/hooks/use-candlestick-data.ts
+++ b/src/hooks/use-candlestick-data.ts
@@ -1,28 +1,28 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from "react";
 import {
   CandlestickData,
   HistogramData,
   LineData,
-  UTCTimestamp
-} from 'lightweight-charts'
+  UTCTimestamp,
+} from "lightweight-charts";
 import {
   computeSMA,
   computeRSI,
   computeMACD,
-  computeBollinger
-} from '@/lib/indicators'
+  computeBollinger,
+} from "@/lib/indicators";
 
 export interface UseCandlestickDataResult {
-  candles: CandlestickData[]
-  volumes: HistogramData[]
-  ma: LineData[]
-  rsi: LineData[]
-  macd: LineData[]
-  signal: LineData[]
-  bollUpper: LineData[]
-  bollLower: LineData[]
-  loading: boolean
-  error: string | null
+  candles: CandlestickData[];
+  volumes: HistogramData[];
+  ma: LineData[];
+  rsi: LineData[];
+  macd: LineData[];
+  signal: LineData[];
+  bollUpper: LineData[];
+  bollLower: LineData[];
+  loading: boolean;
+  error: string | null;
 }
 
 /**
@@ -31,65 +31,76 @@ export interface UseCandlestickDataResult {
  * @param interval - 時間枠
  * @returns 各種データと状態
  */
+export interface UseCandlestickDataOptions {
+  enabled?: boolean;
+}
+
 export function useCandlestickData(
   symbol: string,
-  interval: string
+  interval: string,
+  options: UseCandlestickDataOptions = {},
 ): UseCandlestickDataResult {
+  const { enabled = true } = options;
   const [candles, setCandles] = useState<CandlestickData[]>(() => {
     try {
-      const stored = localStorage.getItem(`candles_${symbol}_${interval}`)
-      return stored ? (JSON.parse(stored) as CandlestickData[]) : []
+      const stored = localStorage.getItem(`candles_${symbol}_${interval}`);
+      return stored ? (JSON.parse(stored) as CandlestickData[]) : [];
     } catch {
-      return []
+      return [];
     }
-  })
+  });
   const [volumes, setVolumes] = useState<HistogramData[]>(() => {
     try {
-      const stored = localStorage.getItem(`volumes_${symbol}_${interval}`)
-      return stored ? (JSON.parse(stored) as HistogramData[]) : []
+      const stored = localStorage.getItem(`volumes_${symbol}_${interval}`);
+      return stored ? (JSON.parse(stored) as HistogramData[]) : [];
     } catch {
-      return []
+      return [];
     }
-  })
-  const [ma, setMa] = useState<LineData[]>([])
-  const [rsi, setRsi] = useState<LineData[]>([])
-  const [macd, setMacd] = useState<LineData[]>([])
-  const [signal, setSignal] = useState<LineData[]>([])
-  const [bollUpper, setBollUpper] = useState<LineData[]>([])
-  const [bollLower, setBollLower] = useState<LineData[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  });
+  const [ma, setMa] = useState<LineData[]>([]);
+  const [rsi, setRsi] = useState<LineData[]>([]);
+  const [macd, setMacd] = useState<LineData[]>([]);
+  const [signal, setSignal] = useState<LineData[]>([]);
+  const [bollUpper, setBollUpper] = useState<LineData[]>([]);
+  const [bollLower, setBollLower] = useState<LineData[]>([]);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<string | null>(null);
 
-  const pricesRef = useRef<number[]>([])
+  const pricesRef = useRef<number[]>([]);
 
   useEffect(() => {
-    let ws: WebSocket | null = null
-    const controller = new AbortController()
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
 
-    setLoading(true)
-    setError(null)
-    pricesRef.current = []
-    setMa([])
-    setRsi([])
-    setMacd([])
-    setSignal([])
-    setBollUpper([])
-    setBollLower([])
+    let ws: WebSocket | null = null;
+    const controller = new AbortController();
+
+    setLoading(true);
+    setError(null);
+    pricesRef.current = [];
+    setMa([]);
+    setRsi([]);
+    setMacd([]);
+    setSignal([]);
+    setBollUpper([]);
+    setBollLower([]);
 
     async function load() {
       try {
-        const url = `https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=${interval}&limit=500`
-        const res = await fetch(url, { signal: controller.signal })
-        if (!res.ok) throw new Error('failed to fetch')
-        const raw = (await res.json()) as any[]
-        const c: CandlestickData[] = []
-        const v: HistogramData[] = []
-        const maArr: LineData[] = []
-        const rsiArr: LineData[] = []
-        const macdArr: LineData[] = []
-        const sigArr: LineData[] = []
-        const bUp: LineData[] = []
-        const bLow: LineData[] = []
+        const url = `https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=${interval}&limit=500`;
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) throw new Error("failed to fetch");
+        const raw = (await res.json()) as any[];
+        const c: CandlestickData[] = [];
+        const v: HistogramData[] = [];
+        const maArr: LineData[] = [];
+        const rsiArr: LineData[] = [];
+        const macdArr: LineData[] = [];
+        const sigArr: LineData[] = [];
+        const bUp: LineData[] = [];
+        const bLow: LineData[] = [];
 
         raw.forEach((d) => {
           const candle: CandlestickData = {
@@ -97,112 +108,137 @@ export function useCandlestickData(
             open: parseFloat(d[1]),
             high: parseFloat(d[2]),
             low: parseFloat(d[3]),
-            close: parseFloat(d[4])
-          }
-          c.push(candle)
+            close: parseFloat(d[4]),
+          };
+          c.push(candle);
 
           const volume: HistogramData = {
             time: (d[0] / 1000) as UTCTimestamp,
             value: parseFloat(d[5]),
-            color: parseFloat(d[4]) >= parseFloat(d[1]) ? '#26a69a' : '#ef5350'
-          }
-          v.push(volume)
+            color: parseFloat(d[4]) >= parseFloat(d[1]) ? "#26a69a" : "#ef5350",
+          };
+          v.push(volume);
 
-          pricesRef.current.push(candle.close)
-          const maVal = computeSMA(pricesRef.current, 14)
-          if (maVal !== null) maArr.push({ time: candle.time, value: maVal })
-          const rsiVal = computeRSI(pricesRef.current, 14)
-          if (rsiVal !== null) rsiArr.push({ time: candle.time, value: rsiVal })
-          const macdVal = computeMACD(pricesRef.current)
+          pricesRef.current.push(candle.close);
+          const maVal = computeSMA(pricesRef.current, 14);
+          if (maVal !== null) maArr.push({ time: candle.time, value: maVal });
+          const rsiVal = computeRSI(pricesRef.current, 14);
+          if (rsiVal !== null)
+            rsiArr.push({ time: candle.time, value: rsiVal });
+          const macdVal = computeMACD(pricesRef.current);
           if (macdVal) {
-            macdArr.push({ time: candle.time, value: macdVal.macd })
-            sigArr.push({ time: candle.time, value: macdVal.signal })
+            macdArr.push({ time: candle.time, value: macdVal.macd });
+            sigArr.push({ time: candle.time, value: macdVal.signal });
           }
-          const bollVal = computeBollinger(pricesRef.current)
+          const bollVal = computeBollinger(pricesRef.current);
           if (bollVal) {
-            bUp.push({ time: candle.time, value: bollVal.upper })
-            bLow.push({ time: candle.time, value: bollVal.lower })
+            bUp.push({ time: candle.time, value: bollVal.upper });
+            bLow.push({ time: candle.time, value: bollVal.lower });
           }
-        })
+        });
 
-        setCandles(c)
-        setVolumes(v)
-        setMa(maArr)
-        setRsi(rsiArr)
-        setMacd(macdArr)
-        setSignal(sigArr)
-        setBollUpper(bUp)
-        setBollLower(bLow)
-        localStorage.setItem(`candles_${symbol}_${interval}`, JSON.stringify(c))
-        localStorage.setItem(`volumes_${symbol}_${interval}`, JSON.stringify(v))
-        setLoading(false)
+        setCandles(c);
+        setVolumes(v);
+        setMa(maArr);
+        setRsi(rsiArr);
+        setMacd(macdArr);
+        setSignal(sigArr);
+        setBollUpper(bUp);
+        setBollLower(bLow);
+        localStorage.setItem(
+          `candles_${symbol}_${interval}`,
+          JSON.stringify(c),
+        );
+        localStorage.setItem(
+          `volumes_${symbol}_${interval}`,
+          JSON.stringify(v),
+        );
+        setLoading(false);
       } catch (e) {
-        console.error(e)
-        setError((e as Error).message)
-        setLoading(false)
+        console.error(e);
+        setError((e as Error).message);
+        setLoading(false);
       }
     }
 
-    load()
+    load();
 
     ws = new WebSocket(
-      `wss://stream.binance.com:9443/ws/${symbol.toLowerCase()}@kline_${interval}`
-    )
+      `wss://stream.binance.com:9443/ws/${symbol.toLowerCase()}@kline_${interval}`,
+    );
     ws.onmessage = (ev) => {
-      const msg = JSON.parse(ev.data)
-      const k = msg.k
+      const msg = JSON.parse(ev.data);
+      const k = msg.k;
       const candle: CandlestickData = {
         time: (k.t / 1000) as UTCTimestamp,
         open: parseFloat(k.o),
         high: parseFloat(k.h),
         low: parseFloat(k.l),
-        close: parseFloat(k.c)
-      }
+        close: parseFloat(k.c),
+      };
       setCandles((prev) => {
-        const arr = [...prev, candle]
-        if (arr.length > 500) arr.shift()
-        localStorage.setItem(`candles_${symbol}_${interval}`, JSON.stringify(arr))
-        return arr
-      })
+        const arr = [...prev, candle];
+        if (arr.length > 500) arr.shift();
+        localStorage.setItem(
+          `candles_${symbol}_${interval}`,
+          JSON.stringify(arr),
+        );
+        return arr;
+      });
 
       const volume: HistogramData = {
         time: (k.t / 1000) as UTCTimestamp,
         value: parseFloat(k.v),
-        color: parseFloat(k.c) >= parseFloat(k.o) ? '#26a69a' : '#ef5350'
-      }
+        color: parseFloat(k.c) >= parseFloat(k.o) ? "#26a69a" : "#ef5350",
+      };
       setVolumes((prev) => {
-        const arr = [...prev, volume]
-        if (arr.length > 500) arr.shift()
-        localStorage.setItem(`volumes_${symbol}_${interval}`, JSON.stringify(arr))
-        return arr
-      })
+        const arr = [...prev, volume];
+        if (arr.length > 500) arr.shift();
+        localStorage.setItem(
+          `volumes_${symbol}_${interval}`,
+          JSON.stringify(arr),
+        );
+        return arr;
+      });
 
-      pricesRef.current.push(candle.close)
-      if (pricesRef.current.length > 1000) pricesRef.current.shift()
-      const maVal = computeSMA(pricesRef.current, 14)
+      pricesRef.current.push(candle.close);
+      if (pricesRef.current.length > 1000) pricesRef.current.shift();
+      const maVal = computeSMA(pricesRef.current, 14);
       if (maVal !== null)
-        setMa((prev) => [...prev, { time: candle.time, value: maVal }])
-      const rsiVal = computeRSI(pricesRef.current, 14)
+        setMa((prev) => [...prev, { time: candle.time, value: maVal }]);
+      const rsiVal = computeRSI(pricesRef.current, 14);
       if (rsiVal !== null)
-        setRsi((prev) => [...prev, { time: candle.time, value: rsiVal }])
-      const macdVal = computeMACD(pricesRef.current)
+        setRsi((prev) => [...prev, { time: candle.time, value: rsiVal }]);
+      const macdVal = computeMACD(pricesRef.current);
       if (macdVal) {
-        setMacd((prev) => [...prev, { time: candle.time, value: macdVal.macd }])
-        setSignal((prev) => [...prev, { time: candle.time, value: macdVal.signal }])
+        setMacd((prev) => [
+          ...prev,
+          { time: candle.time, value: macdVal.macd },
+        ]);
+        setSignal((prev) => [
+          ...prev,
+          { time: candle.time, value: macdVal.signal },
+        ]);
       }
-      const bollVal = computeBollinger(pricesRef.current)
+      const bollVal = computeBollinger(pricesRef.current);
       if (bollVal) {
-        setBollUpper((prev) => [...prev, { time: candle.time, value: bollVal.upper }])
-        setBollLower((prev) => [...prev, { time: candle.time, value: bollVal.lower }])
+        setBollUpper((prev) => [
+          ...prev,
+          { time: candle.time, value: bollVal.upper },
+        ]);
+        setBollLower((prev) => [
+          ...prev,
+          { time: candle.time, value: bollVal.lower },
+        ]);
       }
-    }
+    };
 
     return () => {
-      controller.abort()
-      ws?.close()
-      pricesRef.current = []
-    }
-  }, [symbol, interval])
+      controller.abort();
+      ws?.close();
+      pricesRef.current = [];
+    };
+  }, [symbol, interval, enabled]);
 
   return {
     candles,
@@ -214,8 +250,8 @@ export function useCandlestickData(
     bollUpper,
     bollLower,
     loading,
-    error
-  }
+    error,
+  };
 }
 
-export default useCandlestickData
+export default useCandlestickData;


### PR DESCRIPTION
## Summary
- remove unused initTime state in `PriceChart`
- allow `useCandlestickData` to disable API/WebSocket via `enabled` option
- pass `useApi` from `CandlestickChart` to `useCandlestickData`
- test that API/websocket behaviour matches `useApi` prop

## Testing
- `pnpm test`