### PR TITLE
Add generic Binance socket types

### DIFF
--- a/src/components/chart/MacdPanel.tsx
+++ b/src/components/chart/MacdPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useRef, useCallback } from 'react'
-import { createChart, IChartApi, ISeriesApi, LineData, HistogramData, UTCTimestamp, CrosshairMode } from 'lightweight-charts'
+import { createChart, IChartApi, ISeriesApi, LineData, HistogramData, UTCTimestamp, CrosshairMode, VisibleLogicalRange } from 'lightweight-charts'
 import IndicatorPanel from './IndicatorPanel'
 import useChartTheme from '@/hooks/use-chart-theme'
 import { preprocessLineData } from '@/lib/chart-utils'
@@ -119,7 +119,7 @@ export default function MacdPanel({ macd, signal, chart, height, onClose }: Macd
     }
 
     if (chart) {
-      const sync = (range: any) => {
+      const sync = (range: VisibleLogicalRange | null) => {
         if (chartRef.current && range !== null) {
           chartRef.current.timeScale().setVisibleLogicalRange(range)
         }

--- a/src/components/chart/PriceChart.tsx
+++ b/src/components/chart/PriceChart.tsx
@@ -3,6 +3,7 @@
 import { createChart, UTCTimestamp, IChartApi, ISeriesApi } from 'lightweight-charts';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import useBinanceSocket from '@/hooks/use-binance-socket';
+import type { BinanceTrade } from '@/types/binance';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   computeSMA,
@@ -22,9 +23,9 @@ export default function PriceChart() {
   const [lastPrice, setLastPrice] = useState<number | null>(null);
   const [priceChange, setPriceChange] = useState<number>(0);
   const [initTime] = useState(Date.now());
-  const { status: connectionStatus } = useBinanceSocket({
+  const { status: connectionStatus } = useBinanceSocket<BinanceTrade>({
     url: 'wss://stream.binance.com:9443/ws/btcusdt@trade',
-    onMessage: useCallback((msg: any) => {
+    onMessage: useCallback((msg: BinanceTrade) => {
       const price = parseFloat(msg.p);
       const time = Math.floor(msg.T / 1000) as UTCTimestamp;
 

--- a/src/components/chart/RsiPanel.tsx
+++ b/src/components/chart/RsiPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useRef, useCallback } from 'react'
-import { createChart, IChartApi, ISeriesApi, LineData, UTCTimestamp, CrosshairMode } from 'lightweight-charts'
+import { createChart, IChartApi, ISeriesApi, LineData, UTCTimestamp, CrosshairMode, VisibleLogicalRange } from 'lightweight-charts'
 import IndicatorPanel from './IndicatorPanel'
 import useChartTheme from '@/hooks/use-chart-theme'
 import { preprocessLineData } from '@/lib/chart-utils'
@@ -93,7 +93,7 @@ export default function RsiPanel({ data, chart, height, onClose }: RsiPanelProps
     }
 
     if (chart) {
-      const sync = (range: any) => {
+      const sync = (range: VisibleLogicalRange | null) => {
         if (chartRef.current && range !== null) {
           chartRef.current.timeScale().setVisibleLogicalRange(range)
         }

--- a/src/hooks/use-binance-socket.ts
+++ b/src/hooks/use-binance-socket.ts
@@ -4,14 +4,14 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
-interface UseBinanceSocketOptions {
+export interface UseBinanceSocketOptions<T = unknown> {
   url: string;
   reconnectInterval?: number;
   enabled?: boolean;
   onOpen?: () => void;
   onClose?: () => void;
   onError?: (e: Event) => void;
-  onMessage?: (data: any) => void;
+  onMessage?: (data: T) => void;
 }
 
 /**
@@ -19,7 +19,7 @@ interface UseBinanceSocketOptions {
  * @param options - 接続オプション
  * @returns 接続ステータス
  */
-export function useBinanceSocket(options: UseBinanceSocketOptions) {
+export function useBinanceSocket<T = unknown>(options: UseBinanceSocketOptions<T>) {
   const {
     url,
     reconnectInterval = 3000,

--- a/src/tests/components/MacdPanel.test.tsx
+++ b/src/tests/components/MacdPanel.test.tsx
@@ -25,4 +25,17 @@ describe('MacdPanel', () => {
     render(<MacdPanel macd={[]} signal={[]} chart={null} height={100} />)
     expect(screen.getByTestId('macd-panel')).toBeInTheDocument()
   })
+
+  it('subscribes to logical range changes', () => {
+    const subscribe = jest.fn()
+    const unsubscribe = jest.fn()
+    const chart = {
+      timeScale: () => ({
+        subscribeVisibleLogicalRangeChange: subscribe,
+        unsubscribeVisibleLogicalRangeChange: unsubscribe
+      })
+    } as any
+    render(<MacdPanel macd={[]} signal={[]} chart={chart} height={100} />)
+    expect(subscribe).toHaveBeenCalled()
+  })
 })

--- a/src/tests/components/RsiPanel.test.tsx
+++ b/src/tests/components/RsiPanel.test.tsx
@@ -24,4 +24,17 @@ describe('RsiPanel', () => {
     render(<RsiPanel data={[]} chart={null} height={100} />)
     expect(screen.getByTestId('rsi-panel')).toBeInTheDocument()
   })
+
+  it('subscribes to logical range changes', () => {
+    const subscribe = jest.fn()
+    const unsubscribe = jest.fn()
+    const chart = {
+      timeScale: () => ({
+        subscribeVisibleLogicalRangeChange: subscribe,
+        unsubscribeVisibleLogicalRangeChange: unsubscribe
+      })
+    } as any
+    render(<RsiPanel data={[]} chart={chart} height={100} />)
+    expect(subscribe).toHaveBeenCalled()
+  })
 })

--- a/src/tests/hooks/use-binance-socket.test.ts
+++ b/src/tests/hooks/use-binance-socket.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import useBinanceSocket from '@/hooks/use-binance-socket'
+import type { BinanceTrade } from '@/types/binance'
 
 class MockWebSocket {
   static instances: MockWebSocket[] = []
@@ -19,12 +20,12 @@ describe('useBinanceSocket', () => {
   it('opens websocket and handles messages', () => {
     const onMessage = jest.fn()
     const { unmount } = renderHook(() =>
-      useBinanceSocket({ url: 'wss://test', onMessage })
+      useBinanceSocket<BinanceTrade>({ url: 'wss://test', onMessage })
     )
     const ws = MockWebSocket.instances[0]
     ws.onopen?.()
-    ws.onmessage?.({ data: JSON.stringify({ foo: 'bar' }) })
-    expect(onMessage).toHaveBeenCalledWith({ foo: 'bar' })
+    ws.onmessage?.({ data: JSON.stringify({ p: '1', T: 123 }) })
+    expect(onMessage).toHaveBeenCalledWith({ p: '1', T: 123 })
     unmount()
   })
 

--- a/src/types/binance.ts
+++ b/src/types/binance.ts
@@ -1,0 +1,6 @@
+export interface BinanceTrade {
+  /** 価格 */
+  p: string
+  /** タイムスタンプ (ミリ秒) */
+  T: number
+}


### PR DESCRIPTION
## Summary
- introduce `BinanceTrade` interface
- update `useBinanceSocket` hook to be generic
- ensure `PriceChart` uses typed messages
- type logical range callbacks in `RsiPanel` and `MacdPanel`
- update tests for typed hooks and panels

## Testing
- `pnpm lint`
- `pnpm test`