### PR TITLE
Remove unused format helper

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,3 +1,0 @@
-export const formatDateTime = (ts: number) =>
-  new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo', hour12: false }).format(new Date(ts));
-

--- a/src/tests/components/message-bubble.test.tsx
+++ b/src/tests/components/message-bubble.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MessageBubble from '@/components/chat/message-bubble'
-import { formatDateTime } from '@/lib/format'
 
 describe('MessageBubble', () => {
   it('displays user label', () => {


### PR DESCRIPTION
## Summary
- delete legacy `src/lib/format.ts`
- clean up `MessageBubble` test to remove unused import

## Testing
- `npx jest src/tests/components/message-bubble.test.tsx --runInBand`
- `npx jest --maxWorkers=2` *(fails: Unable to find `[data-testid="typing-indicator"]` etc.)*